### PR TITLE
Add process / machine address to metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+fdb.cluster

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing guide
+
+## Local FoundationDB cluster
+
+You can run a fully working foundationDB cluster (3 nodes):
+
+```
+docker compose up -d
+```
+
+## Running the exporter locally
+
+**You need to have `fdbcli` installed on your system, see
+[apple/foundationdb](https://github.com/apple/foundationdb/releases)**
+
+Generate `fdb.cluster` file from copying from `fdb-exporter` container:
+
+```
+export CONTAINER_ID=$(docker ps | grep "fdb-exporter" | awk '{print $1}')
+docker cp ${CONTAINER_ID}:/etc/foundationdb/fdb.cluster ./fdb.cluster
+```
+
+Run the project and be sure to set the location of the `fdb.cluster` file:
+
+```
+export FDB_CLUSTER_FILE="$PWD/fdb.cluster"
+cargo run
+```
+
+
+## Implement a new metric
+
+We want to have a symetric structure between `status_models` and `prometheus` exporter
+files. A trait is available for new structs: `MetricsConvertible`. When using it,
+you should ensure its method `to_metric()` is called by its upper struct in models.
+
+1. Ensure the metric is not yet available by exploring `src/metrics/prometheus/`
+2. Check the status key is available in models `src/status_models`, if not, add
+   necessary structs for it
+3. Implemenent `MetricsConvertible` (`src/metrics/mod.rs`) on the new struct, or
+   update existin.
+4. Ensure `to_metrics()` method is called on your new implementation

--- a/METRICS.md
+++ b/METRICS.md
@@ -2,147 +2,147 @@
 
 | Name | Description | Labels | Type |
 | ---  | ----------- | --- | ---- |
-| `fdb_client_coordinator_reachable` | Whether the coordinator is reachable | `["address"]` | GAUGE |
-| `fdb_client_coordinators_count` | Number of coordinators registered in client fdb.cluster | `null` | GAUGE |
-| `fdb_client_messages_count` | Number of messages available when fetching status | `null` | GAUGE |
-| `fdb_client_quorum_reachable` | The quorum of coordinators is reachable | `null` | GAUGE |
-| `fdb_client_timestamp` | Client timestamp when last fetched | `null` | GAUGE |
-| `fdb_cluster_average_partition_size_bytes` | Average size for a partition in the cluster | `null` | GAUGE |
-| `fdb_cluster_generation_count` | Number of generations | `null` | GAUGE |
-| `fdb_cluster_healthy` | Whether the cluster is healthy or not | `null` | GAUGE |
-| `fdb_cluster_latency_commit_seconds` | Time in seconds to commit a transaction | `null` | GAUGE |
-| `fdb_cluster_latency_read_seconds` | Time in seconds to read | `null` | GAUGE |
-| `fdb_cluster_latency_transaction_start_seconds` | Time in seconds to start a transaction | `null` | GAUGE |
-| `fdb_cluster_least_space_log_server_bytes` | Value of the log server with least space available | `null` | GAUGE |
-| `fdb_cluster_least_space_storage_server_bytes` | Value of the storage server with least space avaiable | `null` | GAUGE |
-| `fdb_cluster_machine_contributing_workers_count` | Number of process workers on the machine | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machine_excluded` | Machine is being excluded of the cluster | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machine_memory_committed_bytes` | Estimated number of bytes of memory not available on the machine | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machine_memory_free_bytes` | Estimated number of bytes of memory that are available on the machine without swapping | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machine_memory_total_bytes` | Estimated number of total physical RAM | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machine_network_received_megabits` | Received megabits | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machine_network_sent_megabits` | Sent megabits | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machine_network_tcp_segment_retransmitted` | Number of TCP segments that have been retransmitted | `["datacenter_id","machine_id"]` | GAUGE |
-| `fdb_cluster_machines_count` | Number of machines available in the cluster | `null` | GAUGE |
-| `fdb_cluster_moving_data_in_flight_bytes` | Data in flight | `null` | GAUGE |
-| `fdb_cluster_moving_data_in_queue_bytes` | Data waiting to be transferred | `null` | GAUGE |
-| `fdb_cluster_partition_count` | Number of partitions | `null` | GAUGE |
-| `fdb_cluster_process_busy` | Busy of the process (value between 0.0 and 1.1) | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_cpu_usage` | Current usage of CPU (between 0 and 1) | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_busy` | Disk is being busy (0.0 to 1.0 value) | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_free_bytes` | Bytes available on the disk used by process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_reads_count` | Number of reads on the disk | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_reads_frequency` | Frequency of reads on the disk | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_reads_sectors` | N/A | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_total_bytes` | Bytes total on the disk used by process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_writes_count` | Number of writes on the disk | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_writes_frequency` | Frequency of writes on the disk | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_disk_writes_sectors` | N/A | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_excluded` | Process is being excluded by the cluster | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_memory_available_bytes` | Available bytes for the current process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_memory_limit_bytes` | Limiting bytes for the current process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_memory_rss_bytes` | N/A | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_memory_unused_allocated_bytes` | N/A | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_memory_used_bytes` | N/A | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_network_connection_errors_freq` | Frequency of connection errors | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_network_connections_closed` | Frequency of connection closed | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_network_connections_established` | Frequency of connection established | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_network_received_megabits` | Megabits received on network | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_network_sent_megabits` | Megabits sent on network | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_bytes_queried_counter` | Frequency of write storage server operations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_bytes_queried_hz` | Frequency of write storage server operations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_bytes_queried_roughness` | Frequency of write storage server operations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_count` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_max` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_mean` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_median` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_min` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_p25` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_p90` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_p95` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_p99` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_batching_window_p99_9` | Commit batching window size latency  | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_count` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_max` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_mean` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_median` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_min` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_p25` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_p90` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_p95` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_p99` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_commit_latency_p99_9` | Latency to commit | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_data_lag_seconds` | Lag in seconds of the process role | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_durable_bytes_counter` | Storage and Log input rates durable | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_durable_bytes_hz` | Storage and Log input rates durable | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_durable_bytes_roughness` | Storage and Log input rates durable | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_durable_lag_seconds` | Lag in seconds of data being durable of the process role | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_fetched_versions_counter` | Frequency of fetched versions in control plane | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_fetched_versions_hz` | Frequency of fetched versions in control plane | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_fetched_versions_roughness` | Frequency of fetched versions in control plane | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_fetches_from_log_counter` | Frequency of fetched data from T logs | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_fetches_from_log_hz` | Frequency of fetched data from T logs | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_fetches_from_log_roughness` | Frequency of fetched data from T logs | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_finished_queries_counter` | Number of finished queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_finished_queries_hz` | Number of finished queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_finished_queries_roughness` | Number of finished queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_input_bytes_counter` | Storage and Log Input Rates | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_input_bytes_hz` | Storage and Log Input Rates | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_input_bytes_roughness` | Storage and Log Input Rates | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_keys_queried_counter` | Frequency of read storage server operations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_keys_queried_hz` | Frequency of read storage server operations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_keys_queried_roughness` | Frequency of read storage server operations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_kvstore_available_bytes` | KVStore available bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_kvstore_free_bytes` | KVStore free bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_kvstore_used_bytes` | KVStore used bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_low_priority_queries_counter` | Number of low prio queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_low_priority_queries_hz` | Number of low prio queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_low_priority_queries_roughness` | Number of low prio queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_mutation_bytes_counter` | Frequency of mutations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_mutation_bytes_hz` | Frequency of mutations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_mutation_bytes_roughness` | Frequency of mutations in bytes | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_mutation_counter` | Frequency of mutation | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_mutation_hz` | Frequency of mutation | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_mutation_roughness` | Frequency of mutation | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_queue_disk_available_bytes` | Available bytes in the queue of a process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_queue_disk_free_bytes` | Free bytes in the queue of a process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_queue_disk_total_bytes` | Total bytes in the queue of a process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_queue_disk_used_bytes` | Used bytes in the queue of a process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_queue_max` | Queue of read queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_count` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_max` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_mean` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_median` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_min` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_p25` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_p90` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_p95` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_p99` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_read_latency_p99_9` | Latency of read | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_total_queries_counter` | Total number of queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_total_queries_hz` | Total number of queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_role_total_queries_roughness` | Total number of queries | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_process_uptime` | Uptime of the process | `["class_type","machine_id","process_id"]` | GAUGE |
-| `fdb_cluster_state` | Current state of the cluster (see src/status_models/cluster_data.rs) | `null` | GAUGE |
-| `fdb_cluster_total_disk_used_bytes` | Total number of bytes used on all disk | `null` | GAUGE |
-| `fdb_cluster_total_kv_size_bytes` | Total number of bytes for all key values | `null` | GAUGE |
-| `fdb_database_available` | Database can receive request (0=unavailable) | `null` | GAUGE |
-| `fdb_database_healthy` | Database healthiness (0=unhealthy) | `null` | GAUGE |
-| `fdb_exporter_parsing_error_count` | Number of parsing errors encountered | `null` | COUNTER |
-| `fdb_qos_batch_transactions_per_second_limit` | Number of batch transactions the cluster allows per second | `null` | GAUGE |
-| `fdb_qos_limiting_data_lag_storage_server_seconds` | Lag of the limiting storage server (seconds) | `null` | GAUGE |
-| `fdb_qos_limiting_data_lag_storage_server_versions` | Lag of the limiting storage server (versions) | `null` | GAUGE |
-| `fdb_qos_limiting_durability_lag_storage_server_seconds` | Durability lag of the limiting storage server (seconds) | `null` | GAUGE |
-| `fdb_qos_limiting_durability_lag_storage_server_versions` | Durability lag of the limiting storage server (versions) | `null` | GAUGE |
-| `fdb_qos_limiting_queue_storage_server_bytes` | Queue of the storage server limiting the system | `null` | GAUGE |
-| `fdb_qos_performance_limited_by_reason` | Reason of the system being limited | `null` | GAUGE |
-| `fdb_qos_transactions_per_second_limit` | Number of transactions the cluster allows per second | `null` | GAUGE |
-| `fdb_qos_worst_data_lag_storage_server_seconds` | Storage server with the worst queue (seconds) | `null` | GAUGE |
-| `fdb_qos_worst_data_lag_storage_server_versions` | Storage server with the worst queue (versions) | `null` | GAUGE |
-| `fdb_qos_worst_durability_lag_storage_server_seconds` | Storage server with the worst durability queue (seconds) | `null` | GAUGE |
-| `fdb_qos_worst_durability_lag_storage_server_versions` | Storage server with the worst durability queue (versions) | `null` | GAUGE |
-| `fdb_qos_worst_queue_log_server_bytes` | Worst queue of log server in bytes | `null` | GAUGE |
-| `fdb_qos_worst_queue_storage_server_bytes` | Worst queue of storage server | `null` | GAUGE |
+| `fdb_client_coordinator_reachable` | Whether the coordinator is reachable | `address` | GAUGE |
+| `fdb_client_coordinators_count` | Number of coordinators registered in client fdb.cluster | `` | GAUGE |
+| `fdb_client_messages_count` | Number of messages available when fetching status | `` | GAUGE |
+| `fdb_client_quorum_reachable` | The quorum of coordinators is reachable | `` | GAUGE |
+| `fdb_client_timestamp` | Client timestamp when last fetched | `` | GAUGE |
+| `fdb_cluster_average_partition_size_bytes` | Average size for a partition in the cluster | `` | GAUGE |
+| `fdb_cluster_generation_count` | Number of generations | `` | GAUGE |
+| `fdb_cluster_healthy` | Whether the cluster is healthy or not | `` | GAUGE |
+| `fdb_cluster_latency_commit_seconds` | Time in seconds to commit a transaction | `` | GAUGE |
+| `fdb_cluster_latency_read_seconds` | Time in seconds to read | `` | GAUGE |
+| `fdb_cluster_latency_transaction_start_seconds` | Time in seconds to start a transaction | `` | GAUGE |
+| `fdb_cluster_least_space_log_server_bytes` | Value of the log server with least space available | `` | GAUGE |
+| `fdb_cluster_least_space_storage_server_bytes` | Value of the storage server with least space avaiable | `` | GAUGE |
+| `fdb_cluster_machine_contributing_workers_count` | Number of process workers on the machine | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machine_excluded` | Machine is being excluded of the cluster | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machine_memory_committed_bytes` | Estimated number of bytes of memory not available on the machine | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machine_memory_free_bytes` | Estimated number of bytes of memory that are available on the machine without swapping | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machine_memory_total_bytes` | Estimated number of total physical RAM | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machine_network_received_megabits` | Received megabits | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machine_network_sent_megabits` | Sent megabits | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machine_network_tcp_segment_retransmitted` | Number of TCP segments that have been retransmitted | `address, datacenter_id, machine_id` | GAUGE |
+| `fdb_cluster_machines_count` | Number of machines available in the cluster | `` | GAUGE |
+| `fdb_cluster_moving_data_in_flight_bytes` | Data in flight | `` | GAUGE |
+| `fdb_cluster_moving_data_in_queue_bytes` | Data waiting to be transferred | `` | GAUGE |
+| `fdb_cluster_partition_count` | Number of partitions | `` | GAUGE |
+| `fdb_cluster_process_busy` | Busy of the process (value between 0.0 and 1.1) | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_cpu_usage` | Current usage of CPU (between 0 and 1) | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_busy` | Disk is being busy (0.0 to 1.0 value) | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_free_bytes` | Bytes available on the disk used by process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_reads_count` | Number of reads on the disk | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_reads_frequency` | Frequency of reads on the disk | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_reads_sectors` | N/A | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_total_bytes` | Bytes total on the disk used by process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_writes_count` | Number of writes on the disk | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_writes_frequency` | Frequency of writes on the disk | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_disk_writes_sectors` | N/A | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_excluded` | Process is being excluded by the cluster | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_memory_available_bytes` | Available bytes for the current process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_memory_limit_bytes` | Limiting bytes for the current process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_memory_rss_bytes` | N/A | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_memory_unused_allocated_bytes` | N/A | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_memory_used_bytes` | N/A | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_network_connection_errors_freq` | Frequency of connection errors | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_network_connections_closed` | Frequency of connection closed | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_network_connections_established` | Frequency of connection established | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_network_received_megabits` | Megabits received on network | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_network_sent_megabits` | Megabits sent on network | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_bytes_queried_counter` | Frequency of write storage server operations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_bytes_queried_hz` | Frequency of write storage server operations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_bytes_queried_roughness` | Frequency of write storage server operations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_count` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_max` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_mean` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_median` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_min` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_p25` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_p90` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_p95` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_p99` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_batching_window_p99_9` | Commit batching window size latency  | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_count` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_max` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_mean` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_median` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_min` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_p25` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_p90` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_p95` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_p99` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_commit_latency_p99_9` | Latency to commit | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_data_lag_seconds` | Lag in seconds of the process role | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_durable_bytes_counter` | Storage and Log input rates durable | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_durable_bytes_hz` | Storage and Log input rates durable | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_durable_bytes_roughness` | Storage and Log input rates durable | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_durable_lag_seconds` | Lag in seconds of data being durable of the process role | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_fetched_versions_counter` | Frequency of fetched versions in control plane | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_fetched_versions_hz` | Frequency of fetched versions in control plane | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_fetched_versions_roughness` | Frequency of fetched versions in control plane | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_fetches_from_log_counter` | Frequency of fetched data from T logs | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_fetches_from_log_hz` | Frequency of fetched data from T logs | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_fetches_from_log_roughness` | Frequency of fetched data from T logs | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_finished_queries_counter` | Number of finished queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_finished_queries_hz` | Number of finished queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_finished_queries_roughness` | Number of finished queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_input_bytes_counter` | Storage and Log Input Rates | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_input_bytes_hz` | Storage and Log Input Rates | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_input_bytes_roughness` | Storage and Log Input Rates | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_keys_queried_counter` | Frequency of read storage server operations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_keys_queried_hz` | Frequency of read storage server operations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_keys_queried_roughness` | Frequency of read storage server operations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_kvstore_available_bytes` | KVStore available bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_kvstore_free_bytes` | KVStore free bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_kvstore_used_bytes` | KVStore used bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_low_priority_queries_counter` | Number of low prio queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_low_priority_queries_hz` | Number of low prio queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_low_priority_queries_roughness` | Number of low prio queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_mutation_bytes_counter` | Frequency of mutations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_mutation_bytes_hz` | Frequency of mutations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_mutation_bytes_roughness` | Frequency of mutations in bytes | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_mutation_counter` | Frequency of mutation | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_mutation_hz` | Frequency of mutation | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_mutation_roughness` | Frequency of mutation | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_queue_disk_available_bytes` | Available bytes in the queue of a process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_queue_disk_free_bytes` | Free bytes in the queue of a process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_queue_disk_total_bytes` | Total bytes in the queue of a process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_queue_disk_used_bytes` | Used bytes in the queue of a process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_queue_max` | Queue of read queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_count` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_max` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_mean` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_median` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_min` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_p25` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_p90` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_p95` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_p99` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_read_latency_p99_9` | Latency of read | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_total_queries_counter` | Total number of queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_total_queries_hz` | Total number of queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_role_total_queries_roughness` | Total number of queries | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_process_uptime` | Uptime of the process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_state` | Current state of the cluster (see src/status_models/cluster_data.rs) | `` | GAUGE |
+| `fdb_cluster_total_disk_used_bytes` | Total number of bytes used on all disk | `` | GAUGE |
+| `fdb_cluster_total_kv_size_bytes` | Total number of bytes for all key values | `` | GAUGE |
+| `fdb_database_available` | Database can receive request (0=unavailable) | `` | GAUGE |
+| `fdb_database_healthy` | Database healthiness (0=unhealthy) | `` | GAUGE |
+| `fdb_exporter_parsing_error_count` | Number of parsing errors encountered | `` | COUNTER |
+| `fdb_qos_batch_transactions_per_second_limit` | Number of batch transactions the cluster allows per second | `` | GAUGE |
+| `fdb_qos_limiting_data_lag_storage_server_seconds` | Lag of the limiting storage server | `` | GAUGE |
+| `fdb_qos_limiting_data_lag_storage_server_versions` | Lag of the limiting storage server | `` | GAUGE |
+| `fdb_qos_limiting_durability_lag_storage_server_seconds` | Durability lag of the limiting storage server | `` | GAUGE |
+| `fdb_qos_limiting_durability_lag_storage_server_versions` | Durability lag of the limiting storage server | `` | GAUGE |
+| `fdb_qos_limiting_queue_storage_server_bytes` | Queue of the storage server limiting the system | `` | GAUGE |
+| `fdb_qos_performance_limited_by_reason` | Reason of the system being limited | `` | GAUGE |
+| `fdb_qos_transactions_per_second_limit` | Number of transactions the cluster allows per second | `` | GAUGE |
+| `fdb_qos_worst_data_lag_storage_server_seconds` | Storage server with the worst queue | `` | GAUGE |
+| `fdb_qos_worst_data_lag_storage_server_versions` | Storage server with the worst queue | `` | GAUGE |
+| `fdb_qos_worst_durability_lag_storage_server_seconds` | Storage server with the worst durability queue | `` | GAUGE |
+| `fdb_qos_worst_durability_lag_storage_server_versions` | Storage server with the worst durability queue | `` | GAUGE |
+| `fdb_qos_worst_queue_log_server_bytes` | Worst queue of log server in bytes | `` | GAUGE |
+| `fdb_qos_worst_queue_storage_server_bytes` | Worst queue of storage server | `` | GAUGE |
 
 
 ## How to generate
@@ -155,5 +155,5 @@
 6. Rewrite the whole table with output data
 
 ```
-./prom2json http://localhost:9090 | jq 'sort_by(.name) | .[] | @text"| `\(.name)` | \(.help) | `\((.metrics[0]?.labels? | try keys catch null))` | \(.type) |"' -r
+./prom2json http://localhost:9090 | jq 'sort_by(.name) | .[] | @text"| `\(.name)` | \(.help) | `\((.metrics[0]?.labels? | try (keys | join(", ")) catch ""))` | \(.type) |"' -r
 ```

--- a/METRICS.md
+++ b/METRICS.md
@@ -123,12 +123,12 @@
 | `fdb_cluster_process_role_total_queries_hz` | Total number of queries | `address, class_type, machine_id, process_id` | GAUGE |
 | `fdb_cluster_process_role_total_queries_roughness` | Total number of queries | `address, class_type, machine_id, process_id` | GAUGE |
 | `fdb_cluster_process_uptime` | Uptime of the process | `address, class_type, machine_id, process_id` | GAUGE |
+| `fdb_cluster_processes_roles` | Current number of process running a specific role | `role` | GAUGE |
 | `fdb_cluster_state` | Current state of the cluster (see src/status_models/cluster_data.rs) | `` | GAUGE |
 | `fdb_cluster_total_disk_used_bytes` | Total number of bytes used on all disk | `` | GAUGE |
 | `fdb_cluster_total_kv_size_bytes` | Total number of bytes for all key values | `` | GAUGE |
 | `fdb_database_available` | Database can receive request (0=unavailable) | `` | GAUGE |
 | `fdb_database_healthy` | Database healthiness (0=unhealthy) | `` | GAUGE |
-| `fdb_exporter_parsing_error_count` | Number of parsing errors encountered | `` | COUNTER |
 | `fdb_qos_batch_transactions_per_second_limit` | Number of batch transactions the cluster allows per second | `` | GAUGE |
 | `fdb_qos_limiting_data_lag_storage_server_seconds` | Lag of the limiting storage server | `` | GAUGE |
 | `fdb_qos_limiting_data_lag_storage_server_versions` | Lag of the limiting storage server | `` | GAUGE |

--- a/README.md
+++ b/README.md
@@ -42,15 +42,7 @@ cargo build --release
 ./target/release/foundationdb-exporter
 ```
 
-## Contributing a new metric
+## Contributing
 
-We want to have a symetric structure between `status_models` and `prometheus` exporter
-files. A trait is available for new structs: `MetricsConvertible`. When using it,
-you should ensure its method `to_metric()` is called by its upper struct in models.
+See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-1. Ensure the metric is not yet available by exploring `src/metrics/prometheus/`
-2. Check the status key is available in models `src/status_models`, if not, add
-   necessary structs for it
-3. Implemenent `MetricsConvertible` (`src/metrics/mod.rs`) on the new struct, or
-   update existin.
-4. Ensure `to_metrics()` method is called on your new implementation

--- a/src/metrics/prometheus/cluster.rs
+++ b/src/metrics/prometheus/cluster.rs
@@ -1,12 +1,18 @@
 use crate::status_models::cluster::ClusterStatus;
 use crate::{metrics::MetricsConvertible, status_models::cluster_process::ClusterClassType};
 use lazy_static::lazy_static;
-use prometheus::{register_int_gauge, IntGauge};
+use prometheus::{register_int_gauge, register_int_gauge_vec, IntGauge, IntGaugeVec};
 
 lazy_static! {
     static ref P_CLUSTER_MACHINES_COUNT: IntGauge = register_int_gauge!(
         "fdb_cluster_machines_count",
         "Number of machines available in the cluster"
+    )
+    .unwrap();
+    static ref P_CLUSTER_PROCESS_ROLES_COUNT: IntGaugeVec = register_int_gauge_vec!(
+        "fdb_cluster_processes_roles",
+        "Current number of process running a specific role",
+        &["role"]
     )
     .unwrap();
     static ref P_CLUSTER_GENERATION_COUNT: IntGauge =
@@ -49,6 +55,12 @@ impl MetricsConvertible for ClusterStatus {
                 &process.address.to_string(),
             ];
             process.to_metrics(&labels);
+        }
+
+        for (role, count) in self.cluster_roles_count() {
+            P_CLUSTER_PROCESS_ROLES_COUNT
+                .with_label_values(&[&role.to_string()])
+                .set(count as i64);
         }
 
         if let Some(latency_probe) = &self.latency_probe {

--- a/src/metrics/prometheus/cluster.rs
+++ b/src/metrics/prometheus/cluster.rs
@@ -22,7 +22,11 @@ impl MetricsConvertible for ClusterStatus {
                 .datacenter_id
                 .clone()
                 .unwrap_or(String::from("default"));
-            let labels = [machine_id.0.as_str(), datacenter_id.as_str()];
+            let labels = [
+                machine_id.0.as_str(),
+                datacenter_id.as_str(),
+                machine.address.as_str(),
+            ];
             machine.to_metrics(&labels);
         }
 

--- a/src/metrics/prometheus/cluster.rs
+++ b/src/metrics/prometheus/cluster.rs
@@ -42,6 +42,7 @@ impl MetricsConvertible for ClusterStatus {
                 machine_id.0.as_str(),
                 process_id.0.as_str(),
                 class_type.as_str(),
+                &process.address.to_string(),
             ];
             process.to_metrics(&labels);
         }

--- a/src/metrics/prometheus/cluster_machines.rs
+++ b/src/metrics/prometheus/cluster_machines.rs
@@ -3,54 +3,56 @@ use crate::status_models::cluster_machine::ClusterMachine;
 use lazy_static::lazy_static;
 use prometheus::{register_gauge_vec, register_int_gauge_vec, GaugeVec, IntGaugeVec};
 
+const MACHINE_LABELS: &[&str] = &["machine_id", "datacenter_id", "address"];
+
 lazy_static! {
     static ref P_CLUSTER_MACHINE_EXCLUDED_GAUGE: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_machine_excluded",
         "Machine is being excluded of the cluster",
-        &["machine_id", "datacenter_id"]
+        MACHINE_LABELS
     )
     .unwrap();
     static ref P_CLUSTER_MACHINE_CONTRIBUTING_WORKERS_GAUGE: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_machine_contributing_workers_count",
         "Number of process workers on the machine",
-        &["machine_id", "datacenter_id"]
+        MACHINE_LABELS
     )
     .unwrap();
     static ref P_CLUSTER_MACHINE_MEMORY_COMMITTED_BYTES_GAUGE: IntGaugeVec =
         register_int_gauge_vec!(
             "fdb_cluster_machine_memory_committed_bytes",
             "Estimated number of bytes of memory not available on the machine",
-            &["machine_id", "datacenter_id"]
+            MACHINE_LABELS
         )
         .unwrap();
     static ref P_CLUSTER_MACHINE_MEMORY_FREE_BYTES_GAUGE: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_machine_memory_free_bytes",
         "Estimated number of bytes of memory that are available on the machine without swapping",
-        &["machine_id", "datacenter_id"]
+        MACHINE_LABELS
     )
     .unwrap();
     static ref P_CLUSTER_MACHINE_MEMORY_TOTAL_BYTES_GAUGE: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_machine_memory_total_bytes",
         "Estimated number of total physical RAM",
-        &["machine_id", "datacenter_id"]
+        MACHINE_LABELS
     )
     .unwrap();
     static ref P_CLUSTER_MACHINE_NETWORK_MEGABITS_RECEIVED_GAUGE: GaugeVec = register_gauge_vec!(
         "fdb_cluster_machine_network_received_megabits",
         "Received megabits",
-        &["machine_id", "datacenter_id"]
+        MACHINE_LABELS
     )
     .unwrap();
     static ref P_CLUSTER_MACHINE_NETWORK_MEGABITS_SENT_GAUGE: GaugeVec = register_gauge_vec!(
         "fdb_cluster_machine_network_sent_megabits",
         "Sent megabits",
-        &["machine_id", "datacenter_id"]
+        MACHINE_LABELS
     )
     .unwrap();
     static ref P_CLUSTER_MACHINE_NETWORK_TCP_RETRANSMITTED_GAUGE: GaugeVec = register_gauge_vec!(
         "fdb_cluster_machine_network_tcp_segment_retransmitted",
         "Number of TCP segments that have been retransmitted",
-        &["machine_id", "datacenter_id"]
+        MACHINE_LABELS
     )
     .unwrap();
 }

--- a/src/metrics/prometheus/cluster_process.rs
+++ b/src/metrics/prometheus/cluster_process.rs
@@ -1,3 +1,4 @@
+use super::PROCESS_LABELS;
 use crate::{metrics::MetricsConvertible, status_models::cluster_process::ClusterProcess};
 use lazy_static::lazy_static;
 use prometheus::{register_gauge_vec, register_int_gauge_vec, GaugeVec, IntGaugeVec};
@@ -6,25 +7,25 @@ lazy_static! {
     static ref P_PROCESS_EXCLUDED: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_excluded",
         "Process is being excluded by the cluster",
-        &["machine_id", "process_id", "class_type"]
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_CPU_USAGE: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_cpu_usage",
         "Current usage of CPU (between 0 and 1)",
-        &["machine_id", "process_id", "class_type"]
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_UPTIME: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_uptime",
         "Uptime of the process",
-        &["machine_id", "process_id", "class_type"]
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_RUN_LOOP_BUSY: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_busy",
         "Busy of the process (value between 0.0 and 1.1)",
-        &["machine_id", "process_id", "class_type"]
+        PROCESS_LABELS,
     )
     .unwrap();
 }

--- a/src/metrics/prometheus/cluster_process_disk.rs
+++ b/src/metrics/prometheus/cluster_process_disk.rs
@@ -1,3 +1,4 @@
+use crate::metrics::prometheus::PROCESS_LABELS;
 use crate::{metrics::MetricsConvertible, status_models::cluster_process_disk::ClusterProcessDisk};
 use lazy_static::lazy_static;
 use prometheus::{register_gauge_vec, register_int_gauge_vec, GaugeVec, IntGaugeVec};
@@ -6,55 +7,55 @@ lazy_static! {
     static ref P_PROCESS_DISK_BUSY: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_disk_busy",
         "Disk is being busy (0.0 to 1.0 value)",
-        &["machine_id", "process_id", "class_type"]
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_DISK_FREE_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_disk_free_bytes",
         "Bytes available on the disk used by process",
-        &["machine_id", "process_id", "class_type"]
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_DISK_TOTAL_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_disk_total_bytes",
         "Bytes total on the disk used by process",
-        &["machine_id", "process_id", "class_type"]
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_DISK_READS_COUNTER: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_disk_reads_count",
         "Number of reads on the disk",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_DISK_READS_FREQ: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_disk_reads_frequency",
         "Frequency of reads on the disk",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_DISK_READS_SECTORS: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_disk_reads_sectors",
         "N/A",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_DISK_WRITES_COUNTER: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_disk_writes_count",
         "Number of writes on the disk",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_DISK_WRITES_FREQ: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_disk_writes_frequency",
         "Frequency of writes on the disk",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS
     )
     .unwrap();
     static ref P_PROCESS_DISK_WRITES_SECTORS: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_disk_writes_sectors",
         "N/A",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS
     )
     .unwrap();
 }

--- a/src/metrics/prometheus/cluster_process_memory.rs
+++ b/src/metrics/prometheus/cluster_process_memory.rs
@@ -1,3 +1,4 @@
+use crate::metrics::prometheus::PROCESS_LABELS;
 use crate::{
     metrics::MetricsConvertible, status_models::cluster_process_memory::ClusterProcessMemory,
 };
@@ -8,31 +9,31 @@ lazy_static! {
     static ref P_PROCESS_MEMORY_AVAILABLE_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_memory_available_bytes",
         "Available bytes for the current process",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_MEMORY_LIMIT_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_memory_limit_bytes",
         "Limiting bytes for the current process",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_MEMORY_RSS_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_memory_rss_bytes",
         "N/A",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_MEMORY_UNUSED_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_memory_unused_allocated_bytes",
         "N/A",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_MEMORY_USED_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_memory_used_bytes",
         "N/A",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
 }

--- a/src/metrics/prometheus/cluster_process_network.rs
+++ b/src/metrics/prometheus/cluster_process_network.rs
@@ -1,3 +1,4 @@
+use super::PROCESS_LABELS;
 use crate::{
     metrics::MetricsConvertible, status_models::cluster_process_network::ClusterProcessNetwork,
 };
@@ -8,31 +9,31 @@ lazy_static! {
     static ref P_PROCESS_NETWORK_CONN_ERRORS: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_network_connection_errors_freq",
         "Frequency of connection errors",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_NETWORK_CONN_CLOSED: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_network_connections_closed",
         "Frequency of connection closed",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_NETWORK_CONN_ESTABLISHED: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_network_connections_established",
         "Frequency of connection established",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_NETWORK_MEGABITS_RECEIVED: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_network_received_megabits",
         "Megabits received on network",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
     static ref P_PROCESS_NETWORK_MEGABITS_SENT: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_network_sent_megabits",
         "Megabits sent on network",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     )
     .unwrap();
 }

--- a/src/metrics/prometheus/cluster_process_role.rs
+++ b/src/metrics/prometheus/cluster_process_role.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use prometheus::{register_gauge_vec, register_int_gauge_vec, GaugeVec, IntGaugeVec};
 
+use crate::metrics::prometheus::PROCESS_LABELS;
 use crate::{
     metrics::{prometheus::AndSet, MetricsConvertible},
     status_models::cluster_process_role::{
@@ -17,61 +18,61 @@ lazy_static! {
     static ref P_KVSTORE_USED_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_role_kvstore_used_bytes",
         "KVStore used bytes",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     static ref P_KVSTORE_AVAILABLE_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_role_kvstore_available_bytes",
         "KVStore available bytes",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     static ref P_KVSTORE_FREE_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_role_kvstore_free_bytes",
         "KVStore free bytes",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
     // Queue related
     static ref P_QUERY_QUEUE_MAX: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_role_queue_max",
         "Queue of read queries",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
     static ref P_QUEUE_DISK_USED_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_role_queue_disk_used_bytes",
         "Used bytes in the queue of a process",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     static ref P_QUEUE_DISK_AVAILABLE_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_role_queue_disk_available_bytes",
         "Available bytes in the queue of a process",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     static ref P_QUEUE_DISK_FREE_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_role_queue_disk_free_bytes",
         "Free bytes in the queue of a process",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     static ref P_QUEUE_DISK_TOTAL_BYTES: IntGaugeVec = register_int_gauge_vec!(
         "fdb_cluster_process_role_queue_disk_total_bytes",
         "Total bytes in the queue of a process",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     // Lag related
     static ref P_DATA_LAG_SECONDS: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_role_data_lag_seconds",
         "Lag in seconds of the process role",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     static ref P_DATA_DURABLE_LAG_SECONDS: GaugeVec = register_gauge_vec!(
         "fdb_cluster_process_role_durable_lag_seconds",
         "Lag in seconds of data being durable of the process role",
-        &["machine_id", "process_id", "class_type"],
+        PROCESS_LABELS,
     ).unwrap();
 
     // Latency related
@@ -100,12 +101,7 @@ impl StaticMetric<GaugeVec> for ClusterProcessRoleFreq {
         for name in stat_name {
             metrics.insert(
                 name.to_string(),
-                register_gauge_vec!(
-                    format!("{}_{}", prefix, name),
-                    desc,
-                    &["machine_id", "process_id", "class_type"]
-                )
-                .unwrap(),
+                register_gauge_vec!(format!("{}_{}", prefix, name), desc, PROCESS_LABELS).unwrap(),
             );
         }
         metrics
@@ -136,12 +132,7 @@ impl StaticMetric<GaugeVec> for LatencyStats {
         for name in stat_name {
             metrics.insert(
                 name.to_string(),
-                register_gauge_vec!(
-                    format!("{}_{}", prefix, name),
-                    desc,
-                    &["machine_id", "process_id", "class_type"],
-                )
-                .unwrap(),
+                register_gauge_vec!(format!("{}_{}", prefix, name), desc, PROCESS_LABELS,).unwrap(),
             );
         }
         metrics

--- a/src/metrics/prometheus/cluster_qos.rs
+++ b/src/metrics/prometheus/cluster_qos.rs
@@ -5,9 +5,11 @@ use prometheus::{
 use std::collections::HashMap;
 
 use crate::{
-    metrics::MetricsConvertible, register_data_lag, set_data_lag,
-    status_models::cluster_qos::ClusterQos,
+    metrics::MetricsConvertible,
+    status_models::{cluster_process_role::DataLag, cluster_qos::ClusterQos},
 };
+
+use super::{AndSet, StaticMetric};
 
 lazy_static! {
     static ref P_LIMITING_QUEUE_STORAGE_SERVER_BYTES: IntGauge = register_int_gauge!(
@@ -15,19 +17,19 @@ lazy_static! {
         "Queue of the storage server limiting the system"
     )
     .unwrap();
-    static ref P_LIMITING_DATA_STORAGE: HashMap<String, GaugeVec> = register_data_lag!(
+    static ref P_LIMITING_DATA_STORAGE: HashMap<String, GaugeVec> = DataLag::register(
         "fdb_qos_limiting_data_lag_storage_server",
         "Lag of the limiting storage server"
     );
-    static ref P_LIMITING_DURABILITY_LAG_STORAGE: HashMap<String, GaugeVec> = register_data_lag!(
+    static ref P_LIMITING_DURABILITY_LAG_STORAGE: HashMap<String, GaugeVec> = DataLag::register(
         "fdb_qos_limiting_durability_lag_storage_server",
         "Durability lag of the limiting storage server"
     );
-    static ref P_WORST_DATA_LAG_STORAGE_SERVER: HashMap<String, GaugeVec> = register_data_lag!(
+    static ref P_WORST_DATA_LAG_STORAGE_SERVER: HashMap<String, GaugeVec> = DataLag::register(
         "fdb_qos_worst_data_lag_storage_server",
         "Storage server with the worst queue"
     );
-    static ref P_WORST_DURABILITY_LAG_STORAGE_SERVER: HashMap<String, GaugeVec> = register_data_lag!(
+    static ref P_WORST_DURABILITY_LAG_STORAGE_SERVER: HashMap<String, GaugeVec> = DataLag::register(
         "fdb_qos_worst_durability_lag_storage_server",
         "Storage server with the worst durability queue"
     );
@@ -61,24 +63,14 @@ lazy_static! {
 impl MetricsConvertible for ClusterQos {
     fn to_metrics(&self, _: &[&str]) {
         P_LIMITING_QUEUE_STORAGE_SERVER_BYTES.set(self.limiting_queue_bytes_storage_server);
-        if let Some(limit_data_store) = &self.limiting_data_lag_storage_server {
-            set_data_lag!(P_LIMITING_DATA_STORAGE, limit_data_store);
-        }
-
-        if let Some(limit_durability_store) = &self.limiting_durability_lag_storage_server {
-            set_data_lag!(P_LIMITING_DURABILITY_LAG_STORAGE, limit_durability_store);
-        }
-
-        if let Some(worst_data_store) = &self.worst_data_lag_storage_server {
-            set_data_lag!(P_WORST_DATA_LAG_STORAGE_SERVER, worst_data_store);
-        }
-
-        if let Some(worst_durability_store) = &self.worst_durability_lag_storage_server {
-            set_data_lag!(
-                P_WORST_DURABILITY_LAG_STORAGE_SERVER,
-                worst_durability_store
-            );
-        }
+        self.limiting_data_lag_storage_server
+            .and_set(&P_LIMITING_DATA_STORAGE);
+        self.limiting_durability_lag_storage_server
+            .and_set(&P_LIMITING_DURABILITY_LAG_STORAGE);
+        self.worst_data_lag_storage_server
+            .and_set(&P_WORST_DATA_LAG_STORAGE_SERVER);
+        self.worst_durability_lag_storage_server
+            .and_set(&P_WORST_DURABILITY_LAG_STORAGE_SERVER);
 
         P_WORST_QUEUE_BYTES_LOG_SERVER.set(self.worst_queue_bytes_log_server);
         P_WORST_QUEUE_BYTES_STORAGE_SERVER.set(self.worst_queue_bytes_storage_server);
@@ -87,5 +79,38 @@ impl MetricsConvertible for ClusterQos {
 
         P_BATCH_TRANSACTIONS_PER_SECOND_LIMIT.set(self.batch_transactions_per_second_limit);
         P_TRANSACTIONS_PER_SERCOND_LIMIT.set(self.transactions_per_second_limit);
+    }
+}
+
+impl StaticMetric<GaugeVec> for DataLag {
+    fn register(prefix: &str, desc: &str) -> HashMap<String, GaugeVec> {
+        let stat_name = &["versions", "seconds"];
+        let mut metrics = HashMap::new();
+        for name in stat_name {
+            metrics.insert(
+                name.to_string(),
+                register_gauge_vec!(
+                    format!("{}_{}", prefix, name),
+                    desc,
+                    &["machine_id", "process_id", "class_type"],
+                )
+                .unwrap(),
+            );
+        }
+        metrics
+    }
+    fn set(&self, metrics: &HashMap<String, GaugeVec>, labels: &[&str]) {
+        let stat_name = &["versions", "seconds"];
+        for name in *stat_name {
+            // Safe as we know already the stat names
+            let metric = metrics.get(name).unwrap();
+            let value: f64 = match name {
+                "versions" => self.versions as f64,
+                "seconds" => self.seconds,
+                // Impossible case
+                &_ => -1.0,
+            };
+            metric.with_label_values(labels).set(value);
+        }
     }
 }

--- a/src/metrics/prometheus/cluster_qos.rs
+++ b/src/metrics/prometheus/cluster_qos.rs
@@ -1,11 +1,9 @@
 use lazy_static::lazy_static;
-use prometheus::{
-    register_gauge, register_int_gauge, Gauge, IntGauge,
-};
+use prometheus::{register_gauge, register_int_gauge, Gauge, IntGauge};
 use std::collections::HashMap;
 
 use crate::{
-    metrics::{MetricsConvertible},
+    metrics::MetricsConvertible,
     status_models::{cluster_process_role::DataLag, cluster_qos::ClusterQos},
 };
 

--- a/src/metrics/prometheus/mod.rs
+++ b/src/metrics/prometheus/mod.rs
@@ -17,6 +17,8 @@ pub mod cluster_process_network;
 pub mod cluster_process_role;
 pub mod cluster_qos;
 
+pub const PROCESS_LABELS: &[&str] = &["machine_id", "process_id", "class_type", "address"];
+
 lazy_static! {
     static ref P_FDB_EXPORTER_PARSING_ERROR: IntCounter = register_int_counter! {
         "fdb_exporter_parsing_error_count",

--- a/src/metrics/prometheus/mod.rs
+++ b/src/metrics/prometheus/mod.rs
@@ -17,45 +17,6 @@ pub mod cluster_process_network;
 pub mod cluster_process_role;
 pub mod cluster_qos;
 
-#[macro_export]
-macro_rules! register_data_lag {
-    ($prefix:expr, $desc:expr, $labels: expr) => {{
-        let mut metrics: HashMap<String, GaugeVec> = HashMap::new();
-        for key_name in ["versions", "seconds"] {
-            let metric = register_gauge_vec!(
-                format!("{}_{}", $prefix, key_name),
-                format!("{} ({})", $desc, key_name),
-                $labels
-            )
-            .unwrap();
-
-            metrics.insert(String::from(key_name), metric);
-        }
-        metrics
-    }};
-
-    ($prefix:expr, $desc:expr) => {
-        register_data_lag!($prefix, $desc, &[])
-    };
-}
-
-#[macro_export]
-macro_rules! set_data_lag {
-    ($key:ident, $data_lag:ident, $labels:expr) => {
-        $key.get("versions")
-            .unwrap()
-            .with_label_values($labels)
-            .set($data_lag.versions as f64);
-        $key.get("seconds")
-            .unwrap()
-            .with_label_values($labels)
-            .set($data_lag.seconds);
-    };
-    ($key:ident, $data_lag:ident) => {
-        set_data_lag!($key, $data_lag, &[]);
-    };
-}
-
 lazy_static! {
     static ref P_FDB_EXPORTER_PARSING_ERROR: IntCounter = register_int_counter! {
         "fdb_exporter_parsing_error_count",

--- a/src/status_models/cluster.rs
+++ b/src/status_models/cluster.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 use super::cluster_probe::ClusterLatencyProbe;
-use super::cluster_process::{ClusterProcess, ProcessId};
+use super::cluster_process::{ClusterClassType, ClusterProcess, ProcessId};
 use super::cluster_qos::ClusterQos;
 
 /// jq: .cluster
@@ -19,4 +19,143 @@ pub struct ClusterStatus {
     pub latency_probe: Option<ClusterLatencyProbe>,
     pub generation: i64,
     pub qos: ClusterQos,
+}
+
+impl ClusterStatus {
+    /// Navigate through all process available and their roles
+    /// and determine the number of process allocated to a role
+    pub fn cluster_roles_count(&self) -> HashMap<ClusterClassType, u8> {
+        let mut output: HashMap<ClusterClassType, u8> = HashMap::new();
+        let processes_roles = self.processes.values().flat_map(|v| &v.roles);
+        for process_role in processes_roles {
+            if process_role.role.is_none() {
+                continue;
+            }
+            let role = process_role.role.as_ref().unwrap();
+            output.entry(*role).and_modify(|e| *e += 1).or_insert(1);
+        }
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        net::{Ipv4Addr, SocketAddrV4},
+    };
+
+    use crate::status_models::{
+        cluster_data::ClusterData,
+        cluster_process::{ClusterClassType, ClusterProcess, ProcessId},
+        cluster_process_role::ClusterProcessRole,
+        cluster_qos::ClusterQos,
+    };
+
+    use super::ClusterStatus;
+
+    impl Default for ClusterProcess {
+        fn default() -> Self {
+            ClusterProcess {
+                address: SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 65535),
+                class_source: None,
+                class_type: None,
+                version: None,
+                machine_id: None,
+                excluded: None,
+                fault_domain: None,
+                memory: None,
+                network: None,
+                run_loop_busy: None,
+                uptime_seconds: None,
+                cpu: None,
+                disk: None,
+                roles: Vec::new(),
+            }
+        }
+    }
+
+    impl Default for ClusterStatus {
+        fn default() -> Self {
+            ClusterStatus {
+                database_available: true,
+                machines: HashMap::new(),
+                data: ClusterData::default(),
+                processes: HashMap::new(),
+                latency_probe: None,
+                generation: 1,
+                qos: ClusterQos::default(),
+            }
+        }
+    }
+
+    fn create_process_with_roles(roles: Vec<ClusterClassType>) -> ClusterProcess {
+        let process_roles = roles
+            .into_iter()
+            .map(|r| ClusterProcessRole {
+                role: Some(r),
+                ..Default::default()
+            })
+            .collect();
+        ClusterProcess {
+            roles: process_roles,
+            ..Default::default()
+        }
+    }
+    #[test]
+    fn count_roles_empty() {
+        let status = ClusterStatus::default();
+        let count = status.cluster_roles_count();
+        assert_eq!(count.len(), 0);
+    }
+
+    #[test]
+    fn count_roles() {
+        let processes = HashMap::from([
+            (
+                ProcessId("first".to_string()),
+                create_process_with_roles(
+                    [ClusterClassType::Coordinator, ClusterClassType::Log].into(),
+                ),
+            ),
+            (
+                ProcessId("second".to_string()),
+                create_process_with_roles(
+                    [ClusterClassType::Storage, ClusterClassType::CommitProxy].into(),
+                ),
+            ),
+            (
+                ProcessId("third".to_string()),
+                create_process_with_roles(
+                    [ClusterClassType::Storage, ClusterClassType::Stateless].into(),
+                ),
+            ),
+        ]);
+        let status = ClusterStatus {
+            processes,
+            ..Default::default()
+        };
+        let count = status.cluster_roles_count();
+
+        assert_eq!(
+            count
+                .get(&ClusterClassType::Coordinator)
+                .unwrap()
+                .to_owned(),
+            1
+        );
+        assert_eq!(count.get(&ClusterClassType::Storage).unwrap().to_owned(), 2);
+        assert_eq!(
+            count.get(&ClusterClassType::Stateless).unwrap().to_owned(),
+            1
+        );
+        assert_eq!(
+            count
+                .get(&ClusterClassType::CommitProxy)
+                .unwrap()
+                .to_owned(),
+            1
+        );
+        assert_eq!(count.get(&ClusterClassType::Log).unwrap().to_owned(), 1);
+    }
 }

--- a/src/status_models/cluster_data.rs
+++ b/src/status_models/cluster_data.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 /// jq: .cluster.data
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Default))]
 pub struct ClusterData {
     pub average_partition_size_bytes: i64,
     pub least_operating_space_bytes_log_server: i64,
@@ -46,6 +47,7 @@ impl Default for ClusterDataStateName {
 
 /// jq: .cluster.data.state
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Default))]
 pub struct ClusterDataState {
     pub healthy: Option<bool>,
     pub description: Option<String>,

--- a/src/status_models/cluster_process.rs
+++ b/src/status_models/cluster_process.rs
@@ -48,7 +48,7 @@ pub enum ClusterClassSource {
     SetClass,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Eq, Hash, PartialEq, Clone, Copy)]
 pub enum ClusterClassType {
     #[serde(rename = "unset")]
     Unset,

--- a/src/status_models/cluster_process_role.rs
+++ b/src/status_models/cluster_process_role.rs
@@ -7,6 +7,7 @@ pub struct RoleId(pub String);
 
 // jq: .cluster.processes[].roles[]
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Default))]
 pub struct ClusterProcessRole {
     pub query_queue_max: Option<f64>,
     pub local_rate: Option<f64>,

--- a/src/status_models/cluster_qos.rs
+++ b/src/status_models/cluster_qos.rs
@@ -4,6 +4,7 @@ use super::{cluster_process::ProcessId, cluster_process_role::DataLag};
 
 /// jq: .cluster.qos
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Default))]
 pub struct ClusterQos {
     pub worst_queue_bytes_log_server: i64,
     pub worst_queue_bytes_storage_server: i64,
@@ -24,6 +25,7 @@ pub struct ClusterQos {
 }
 
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Default))]
 pub struct ClusterPerformanceLimit {
     pub reason_server_id: Option<ProcessId>,
     pub reason_id: i64,


### PR DESCRIPTION
* Remove previously used macro `register_data_lag` for `DataLag` struct in favor of `StaticMetric` trait which is more convenient
* Add to all `cluster.processes[]` metrics a `address` label which is listening address (ip+port)
* Add to all `cluster.machines[]` metrics `address` label (only ip)
* Improve `METRICS.md` table format for labels
* Create a `CONTRIBUTING.md` file to have basic commands for setup
* Implement a new metric to get the count of processes running a specific role

```
# HELP fdb_cluster_processes_roles Current number of process running a specific role
# TYPE fdb_cluster_processes_roles gauge
fdb_cluster_processes_roles{role="cluster_controller"} 1
fdb_cluster_processes_roles{role="commit_proxy"} 1
fdb_cluster_processes_roles{role="coordinator"} 1
fdb_cluster_processes_roles{role="data_distributor"} 1
fdb_cluster_processes_roles{role="grv_proxy"} 1
fdb_cluster_processes_roles{role="log"} 1
fdb_cluster_processes_roles{role="resolver"} 1
fdb_cluster_processes_roles{role="storage"} 3
```

Closes #3 