### PR TITLE
Listen ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Usage: fdbexporter [OPTIONS]
 
 Options:
   -p, --port <PORT>            Listening port of the web server [env: FDB_EXPORTER_PORT=] [default: 9090]
+  -a, --addr                   Listening IPv4/IPv6 address of the web server [env: FDB_EXPORTER_ADDR=] [default: 0.0.0.0]
   -c, --cluster <CLUSTER>      Location of fdb.cluster file [env: FDB_CLUSTER_FILE=]
   -d, --delay-sec <DELAY_SEC>  Delay in seconds between two update of the status & metrics [env: FDB_EXPORTER_DELAY=] [default: 15]
   -h, --help                   Print help


### PR DESCRIPTION
We previously introduced a change to allow the exporter to successfully scrape metrics from an FDB cluster that was running on IPv6 as opposed to IPv4.

This change allows the exporter itself to listen in IPv6 by exposing a `--addr` flag to allow users to specify the listening address themselves. The listening address can be either IPv4 or IPv6 and defaults to `0.0.0.0.`

Closes #19 