### PR TITLE
Update software versions in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG FDB_VERSION=7.3.43
-ARG RUST_VERSION=1.91.0
+ARG FDB_VERSION=7.3.69
+ARG RUST_VERSION=1.93.0
 # Build Stage
-FROM rust:${RUST_VERSION}-bullseye AS builder
+FROM rust:${RUST_VERSION}-trixie AS builder
 
 ARG FDB_VERSION
 
@@ -29,11 +29,11 @@ RUN if echo "${FDB_VERSION}" | grep -q "^7\.1\."; then \
     cargo build --release ${CARGO_FEATURES}
 
 # Final Stage
-FROM debian:bullseye
+FROM debian:trixie-slim
 ARG FDB_VERSION
 WORKDIR /app
 
-RUN apt update && apt install -y wget curl dnsutils openssh-client
+RUN apt update && apt install -y wget curl dnsutils openssh-client && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download foundationdb client
 RUN wget -q https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients_${FDB_VERSION}-1_amd64.deb \


### PR DESCRIPTION
This is a small update of software versions used in the Docker image:

- Debian Bullseye is 7 months away from end of life, upgrade it to Trixie
- Bump Rust and FDB versions too
- Additional optimization: drop apt caches after package install

The 2.3.0-7.3.69 image has at the time of writing 191 vulnerabilities, including 4 criticals.
The new version is down to 124, without any criticals. (And it's also about 46 MB smaller in size.)