### PR TITLE
Use timeout when fetching status from FDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ A monitoring tool for FoundationDB with exporting capabilities for prometheus
 Usage: fdbexporter [OPTIONS]
 
 Options:
-  -p, --port <PORT>            Listening port of the web server [env: FDB_EXPORTER_PORT=] [default: 9090]
-  -a, --addr                   Listening IPv4/IPv6 address of the web server [env: FDB_EXPORTER_ADDR=] [default: 0.0.0.0]
-  -c, --cluster <CLUSTER>      Location of fdb.cluster file [env: FDB_CLUSTER_FILE=]
-  -d, --delay-sec <DELAY_SEC>  Delay in seconds between two update of the status & metrics [env: FDB_EXPORTER_DELAY=] [default: 15]
-  -h, --help                   Print help
-  -V, --version                Print version
+  -p, --port <PORT>                Listening port of the web server [env: FDB_EXPORTER_PORT=] [default: 9090]
+  -a, --addr <ADDR>                Listening IPv4/IPv6 address of the web server [env: FDB_EXPORTER_ADDR=] [default: 0.0.0.0]
+  -c, --cluster <CLUSTER>          Location of fdb.cluster file [env: FDB_CLUSTER_FILE=]
+  -d, --delay-sec <DELAY_SEC>      Delay in seconds between two update of the status & metrics [env: FDB_EXPORTER_DELAY=] [default: 15]
+  -t, --fdb-timeout <FDB_TIMEOUT>  Timeout in seconds for FoundationDB status fetch operations [env: FDB_TIMEOUT=] [default: 60]
+  -h, --help                       Print help
+  -V, --version                    Print version
 ```
 
 ### Running with a sample FoundationDB Cluster

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 use foundationdb::{options::TransactionOption, Database, FdbBindingError, FdbError};
 use tracing::error;
@@ -16,6 +16,8 @@ pub enum FetchError {
     FdbBinding(FdbBindingError),
     /// Error when the status key is not found
     StatusNotFound,
+    /// Error when the requested timeout is too large
+    TimeoutTooLarge(u128),
 }
 
 impl std::fmt::Display for FetchError {
@@ -25,6 +27,14 @@ impl std::fmt::Display for FetchError {
             FetchError::Fdb(e) => write!(f, "FoundationDB error: {}", e),
             FetchError::FdbBinding(e) => write!(f, "FoundationDB binding error: {}", e),
             FetchError::StatusNotFound => write!(f, "Status key not found in FoundationDB"),
+            FetchError::TimeoutTooLarge(ms) => {
+                write!(
+                    f,
+                    "Timeout value {}ms exceeds maximum of {}ms (i32::MAX)",
+                    ms,
+                    i32::MAX
+                )
+            }
         }
     }
 }
@@ -36,6 +46,7 @@ impl std::error::Error for FetchError {
             FetchError::Fdb(e) => Some(e),
             FetchError::FdbBinding(e) => Some(e),
             FetchError::StatusNotFound => None,
+            FetchError::TimeoutTooLarge(_) => None,
         }
     }
 }
@@ -57,6 +68,7 @@ impl From<FdbBindingError> for FetchError {
 /// # Arguments
 ///
 /// * `cluster_file` - Optional path to the cluster file. If None, uses the default cluster file.
+/// * `timeout_duration` - Timeout to use when querying for status.
 ///
 /// # Returns
 ///
@@ -67,18 +79,24 @@ impl From<FdbBindingError> for FetchError {
 ///
 /// ```no_run
 /// use fdbexporter::fetch_cluster_status;
-/// use std::path::Path;
+/// use std::{path::Path, time::Duration};
 ///
 /// # async fn example() -> Result<(), fdbexporter::FetchError> {
+///
+/// let timeout = Duration::new(15, 0);
+///
 /// // Use default cluster file
-/// let status = fetch_cluster_status(None).await?;
+/// let status = fetch_cluster_status(None, timeout).await?;
 ///
 /// // Use custom cluster file
-/// let status = fetch_cluster_status(Some(Path::new("/etc/foundationdb/fdb.cluster"))).await?;
+/// let status = fetch_cluster_status(Some(Path::new("/etc/foundationdb/fdb.cluster")), timeout).await?;
 /// # Ok(())
 /// # }
 /// ```
-pub async fn fetch_cluster_status(cluster_file: Option<&Path>) -> Result<Status, FetchError> {
+pub async fn fetch_cluster_status(
+    cluster_file: Option<&Path>,
+    timeout_duration: Duration,
+) -> Result<Status, FetchError> {
     let db = if let Some(path) = cluster_file {
         let path_str = path.to_str().ok_or_else(|| {
             // Create a custom error for invalid path
@@ -92,11 +110,17 @@ pub async fn fetch_cluster_status(cluster_file: Option<&Path>) -> Result<Status,
         Database::default()?
     };
 
+    let timeout_millis = timeout_duration
+        .as_millis()
+        .try_into()
+        .map_err(|_| FetchError::TimeoutTooLarge(timeout_duration.as_millis()))?;
+
     // Read the status JSON from the system key
     let status_json = db
         .run(|trx, _maybe_committed| async move {
             // Set the option to read system keys
             trx.set_option(TransactionOption::ReadSystemKeys)?;
+            trx.set_option(TransactionOption::Timeout(timeout_millis))?;
 
             // The status JSON is stored at the special key \xff\xff/status/json
             let status_key = b"\xff\xff/status/json";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,20 +19,22 @@
 //!
 //! ```no_run
 //! use fdbexporter::{fetch_cluster_status, process_metrics};
-//! use std::path::Path;
+//! use std::{path::Path, time::Duration};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Initialize FoundationDB client (once per process)
 //! let _guard = unsafe { foundationdb::boot() };
 //!
+//! let timeout = Duration::new(15, 0);
+//!
 //! // Fetch status using default cluster file
-//! match fetch_cluster_status(None).await {
+//! match fetch_cluster_status(None, timeout).await {
 //!     Ok(status) => process_metrics(status),
 //!     Err(e) => eprintln!("Failed to fetch status: {:?}", e),
 //! }
 //!
 //! // Or use a custom cluster file
-//! match fetch_cluster_status(Some(Path::new("/etc/foundationdb/fdb.cluster"))).await {
+//! match fetch_cluster_status(Some(Path::new("/etc/foundationdb/fdb.cluster")), timeout).await {
 //!     Ok(status) => process_metrics(status),
 //!     Err(e) => eprintln!("Failed to fetch status: {:?}", e),
 //! }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ async fn run_status_fetcher(config: &CommandArgs) -> Result<(), anyhow::Error> {
     let cluster_path = config.cluster.as_deref();
 
     loop {
-        let status = fetch_cluster_status(cluster_path).await;
+        let status = fetch_cluster_status(cluster_path, config.fdb_timeout).await;
 
         match status {
             Ok(status) => process_metrics(status),
@@ -83,11 +83,33 @@ struct CommandArgs {
     /// Delay in seconds between two update of the status & metrics
     #[arg(short, long, env = "FDB_EXPORTER_DELAY", value_parser = parse_duration, default_value = "15")]
     delay_sec: Duration,
+
+    /// Timeout in seconds for FoundationDB status fetch operations
+    #[arg(short = 't', long, env = "FDB_TIMEOUT", value_parser = parse_fdb_timeout, default_value = "60")]
+    fdb_timeout: Duration,
 }
 
 fn parse_duration(arg: &str) -> Result<Duration, ParseIntError> {
     let seconds = arg.parse()?;
     Ok(Duration::from_secs(seconds))
+}
+
+fn parse_fdb_timeout(arg: &str) -> Result<Duration, String> {
+    let seconds: u64 = arg
+        .parse()
+        .map_err(|e| format!("Invalid timeout value: {}", e))?;
+
+    if seconds == 0 {
+        return Err("Timeout must be greater than 0".to_string());
+    }
+
+    let duration = Duration::from_secs(seconds);
+    let _millis: i32 = duration
+        .as_millis()
+        .try_into()
+        .map_err(|_| "Timeout value too large to fit in i32 milliseconds".to_string())?;
+
+    Ok(duration)
 }
 
 #[tokio::main]
@@ -132,6 +154,7 @@ mod tests {
                 addr: std::net::IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
                 cluster: None,
                 delay_sec: Duration::from_secs(1),
+                fdb_timeout: Duration::from_secs(60),
             }
         }
     }

--- a/src/metrics/prometheus/mod.rs
+++ b/src/metrics/prometheus/mod.rs
@@ -51,6 +51,7 @@ impl MetricsConvertible for FetchError {
             FetchError::FdbBinding(_) => P_FDB_EXPORTER_FDB_BINDING_ERROR.inc(),
             FetchError::StatusNotFound => P_FDB_EXPORTER_STATUS_NOT_FOUND.inc(),
             FetchError::Parsing(_) => P_FDB_EXPORTER_PARSING_ERROR.inc(),
+            FetchError::TimeoutTooLarge(_) => (),
         };
     }
 }


### PR DESCRIPTION
Since the exporter delay controls how-often we expect scrape status, use the same delay as a timeout for fetching the status.

Closes #21 