### PR TITLE
feat: add native fdb-7_4 feature and make it default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 required-features = ["binary"]
 
 [features]
-default = ["binary", "fdb-7_3"]
+default = ["binary", "fdb-7_4"]
 binary = [
     "dep:tokio",
     "dep:hyper",
@@ -30,6 +30,7 @@ binary = [
 ]
 fdb-7_1 = ["foundationdb/fdb-7_1"]
 fdb-7_3 = ["foundationdb/fdb-7_3"]
+fdb-7_4 = ["foundationdb/fdb-7_4"]
 
 [dependencies]
 # Core library dependencies (always available)

--- a/build.rs
+++ b/build.rs
@@ -5,12 +5,24 @@ fn main() {
          Please enable only one FoundationDB version feature."
     );
 
-    #[cfg(not(any(feature = "fdb-7_1", feature = "fdb-7_3")))]
+    #[cfg(all(feature = "fdb-7_1", feature = "fdb-7_4"))]
+    compile_error!(
+        "Features 'fdb-7_1' and 'fdb-7_4' are mutually exclusive. \
+         Please enable only one FoundationDB version feature."
+    );
+
+    #[cfg(all(feature = "fdb-7_3", feature = "fdb-7_4"))]
+    compile_error!(
+        "Features 'fdb-7_3' and 'fdb-7_4' are mutually exclusive. \
+         Please enable only one FoundationDB version feature."
+    );
+
+    #[cfg(not(any(feature = "fdb-7_1", feature = "fdb-7_3", feature = "fdb-7_4")))]
     {
         println!(
             "cargo:warning=No FoundationDB version feature enabled. \
-             Consider enabling either 'fdb-7_1' or 'fdb-7_3'. \
-             Default is 'fdb-7_3'."
+             Consider enabling one of 'fdb-7_1', 'fdb-7_3', or 'fdb-7_4'. \
+             Default is 'fdb-7_4'."
         );
     }
 }


### PR DESCRIPTION
The foundationdb crate v0.10.0 already exposes fdb-7_4, so wire it
through as a feature and select API version 740 by default. This aligns
the exporter natively with FoundationDB 7.4.x clusters instead of
relying on 7.3-client backward compatibility.

- `Cargo.toml`: add `fdb-7_4 = ["foundationdb/fdb-7_4"]`; default to it
- `build.rs`: extend mutual-exclusion checks to the three-way set
  (`fdb-7_1` / `fdb-7_3` / `fdb-7_4`) and fix the stale
  "Default is 'fdb-7_3'" warning string

**Note — behavior change for default builds:** the default feature set is
now `["binary", "fdb-7_4"]` (API version 740) instead of `fdb-7_3` (730).
Consumers building with default features will link the 7.4 client API. To
keep the previous behavior, build with
`--no-default-features --features binary,fdb-7_3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)